### PR TITLE
Adds https support and reworks linter/test scripts

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -38,15 +38,15 @@ function fetch (url, cb) {
   var request
 
   if (protocol === 'http:') {
-    request = http.get(url, callback)
+    request = http.get(url, handleGet)
   } else if (protocol === 'https:') {
-    request = https.get(url, callback)
+    request = https.get(url, handleGet)
   } else {
     return cb(new Error('Unknown protocol: ' + protocol + ' for ' + url))
   }
   request.on('error', resolve)
 
-  function callback (res) {
+  function handleGet (res) {
     if (res.statusCode !== 200) {
       return cb(new Error('Unexpected status code ' + res.statusCode + ' for ' + url))
     }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var http = require('http')
+var https = require('https')
 var semver = require('semver')
 var util = require('util')
 var config = require('./config')
@@ -31,8 +32,20 @@ function fetch (url, cb) {
 
   pending[url] = [cb]
   var resolve = resolvePending.bind(null, url)
+  var parsedUrl = url.parse(url)
+  var protocol = parsedUrl.protocol
+  var request
 
-  http.get(url, function (res) {
+  if (protocol === 'http') {
+    request = http.get(url, callback)
+  } else if (protocol === 'https') {
+    request = https.get(url, callback)
+  } else {
+    return cb(new Error('Unknown protocol: ' + protocol + ' for ' + url))
+  }
+  request.on('error', resolve)
+
+  function callback (res) {
     if (res.statusCode !== 200) {
       return cb(new Error('Unexpected status code ' + res.statusCode + ' for ' + url))
     }
@@ -56,7 +69,7 @@ function fetch (url, cb) {
       }
     })
     res.on('error', resolve)
-  }).on('error', resolve)
+  }
 }
 
 /**

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -37,9 +37,9 @@ function fetch (url, cb) {
   var protocol = parsedUrl.protocol
   var request
 
-  if (protocol === 'http') {
+  if (protocol === 'http:') {
     request = http.get(url, callback)
-  } else if (protocol === 'https') {
+  } else if (protocol === 'https:') {
     request = https.get(url, callback)
   } else {
     return cb(new Error('Unknown protocol: ' + protocol + ' for ' + url))

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -2,6 +2,7 @@
 
 var http = require('http')
 var https = require('https')
+var urlModule = require('url')
 var semver = require('semver')
 var util = require('util')
 var config = require('./config')
@@ -32,7 +33,7 @@ function fetch (url, cb) {
 
   pending[url] = [cb]
   var resolve = resolvePending.bind(null, url)
-  var parsedUrl = url.parse(url)
+  var parsedUrl = urlModule.parse(url)
   var protocol = parsedUrl.protocol
   var request
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "tar-fs": "^1.8.1"
   },
   "devDependencies": {
-    "lodash": "^3.10.1",
     "mocha": "^2.3.3",
     "mock-fs": "^3.4.0",
     "mockmock": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "tar-fs": "^1.8.1"
   },
   "devDependencies": {
+    "lodash": "^3.10.1",
     "mocha": "^2.3.3",
     "mock-fs": "^3.4.0",
     "mockmock": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,14 @@
     "mockmock": "0.0.5",
     "proxyquire": "^1.7.3",
     "rimraf": "^2.4.3",
+    "snazzy": "^2.0.1",
     "standard": "^5.3.1",
     "tape": "^4.2.2"
   },
   "scripts": {
-    "test": "mocha --recursive && standard"
+    "test": "mocha --recursive",
+    "pretest": "npm run lint",
+    "lint": "standard | snazzy"
   },
   "repository": {
     "type": "git",

--- a/test/unit/resolve.js
+++ b/test/unit/resolve.js
@@ -1,175 +1,185 @@
 /* global describe it beforeEach */
 
+var _ = require('lodash')
 var proxyquire = require('proxyquire')
 var assert = require('assert')
 var mock = require('mockmock')
 var EventEmitter = require('events').EventEmitter
+var config = require('../../lib/config')
 
 describe('resolve', function () {
-  var resolve
-  var http
-  var cb
-  var httpResp
-  var httpGet
+  var protocols = ['http', 'https']
+  protocols.forEach(function (protocol) {
+    describe(protocol, function () {
+      var http
+      var cb
+      var httpResp
+      var httpGet
+      var resolve
+      beforeEach(function () {
+        httpResp = new EventEmitter()
+        httpGet = new EventEmitter()
+        http = { get: mock(httpGet) }
+        var dummyConfig = _.clone(config)
+        dummyConfig.registry = protocol + '://registry.npmjs.org/'
+        cb = mock()
 
-  beforeEach(function () {
-    httpResp = new EventEmitter()
-    httpGet = new EventEmitter()
-    http = { get: mock(httpGet) }
-    cb = mock()
+        resolve = proxyquire('../../lib/resolve', {
+          './config': dummyConfig,
+          http: http,
+          https: http
+        })
+      })
 
-    resolve = proxyquire('../../lib/resolve', {
-      http: http
+      it('should fetch from correct endpoint', function () {
+        var name = 'some-package'
+        var version = '~1.0.0'
+        resolve(name, version, cb)
+
+        assert.deepEqual(http.get.args[0][0], protocol + '://registry.npmjs.org/' + name)
+      })
+
+      it('should accept optional callback', function () {
+        var err = new Error()
+        resolve('some-package', '~1.0.0')
+
+        assert.doesNotThrow(function () {
+          httpGet.emit('error', err)
+        })
+      })
+
+      it('should handle HTTP connection error', function () {
+        var err = new Error()
+        resolve('some-package', '~1.0.0', cb)
+        httpGet.emit('error', err)
+        assert.equal(cb.args[0][0], err)
+      })
+
+      it('should handle HTTP error while receiving data', function () {
+        var err = new Error()
+        resolve('some-package', '~1.0.0', cb)
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+        httpResp.emit('data', 'some data')
+        httpResp.emit('error', err)
+        assert.equal(cb.args[0][0], err)
+      })
+
+      it('should handle invalid statusCode', function () {
+        resolve('some-package', '~1.0.0', cb)
+        httpResp.statusCode = 404
+        http.get.args[0][1](httpResp)
+        httpResp.emit('data', '{}')
+        httpResp.emit('end')
+        assert(cb.args[0][0])
+      })
+
+      it('should handle invalid JSON response', function () {
+        resolve('some-package', '~1.0.0', cb)
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+        httpResp.emit('data', 'some data')
+        httpResp.emit('data', 'some more data')
+        httpResp.emit('end')
+        assert(cb.args[0][0] instanceof SyntaxError)
+      })
+
+      it('should validate JSON response schema to have plain object property "versions', function () {
+        resolve('some-package', '~1.0.0', cb)
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+        httpResp.emit('data', JSON.stringify({
+          versions: []
+        }))
+        httpResp.emit('end')
+        assert(cb.args[0][0] instanceof SyntaxError)
+      })
+
+      it('should handle case of no matching version', function () {
+        resolve('some-package', '~5.0.0', cb)
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+        httpResp.emit('data', JSON.stringify({
+          versions: {
+            '0.0.1': {},
+            '1.0.0': {},
+            '2.0.0': {}
+          }
+        }))
+        httpResp.emit('end')
+        assert(cb.args[0][0] instanceof Error)
+      })
+
+      it('should resolve to latest correct version', function () {
+        resolve('some-package', '~1.1.0', cb)
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+        httpResp.emit('data', JSON.stringify({
+          versions: {
+            '0.0.1': { version: '0.0.1' },
+            '1.0.0': { version: '1.0.0' },
+            '1.1.0': { version: '1.1.0' },
+            '2.0.0': { version: '2.0.0' }
+          }
+        }))
+        httpResp.emit('end')
+        assert.ifError(cb.args[0][0])
+        assert.deepEqual(cb.args[0][1], { version: '1.1.0' })
+      })
+
+      it('should properly handle pending requests', function () {
+        var cb2 = mock()
+
+        resolve('some-package', '~1.1.0', cb)
+        resolve('some-package', '~2.0.0', cb2)
+
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+
+        httpResp.emit('data', JSON.stringify({
+          versions: {
+            '0.0.1': { version: '0.0.1' },
+            '1.0.0': { version: '1.0.0' },
+            '1.1.0': { version: '1.1.0' },
+            '2.0.0': { version: '2.0.0' }
+          }
+        }))
+        httpResp.emit('end')
+
+        assert.ifError(cb.args[0][0])
+        assert.ifError(cb2.args[0][0])
+        assert.deepEqual(cb.args[0][1], { version: '1.1.0' })
+        assert.deepEqual(cb2.args[0][1], { version: '2.0.0' })
+      })
+
+      it('should properly cache requests', function () {
+        resolve('some-package', '~1.1.0', cb)
+
+        httpResp.statusCode = 200
+        http.get.args[0][1](httpResp)
+
+        httpResp.emit('data', JSON.stringify({
+          versions: {
+            '0.0.1': { version: '0.0.1' },
+            '1.0.0': { version: '1.0.0' },
+            '1.1.0': { version: '1.1.0' },
+            '2.0.0': { version: '2.0.0' }
+          }
+        }))
+        httpResp.emit('end')
+
+        assert.ifError(cb.args[0][0])
+        assert.deepEqual(cb.args[0][1], { version: '1.1.0' })
+
+        var cb2 = mock()
+        resolve('some-package', '~2.0.0', cb2)
+
+        assert.ifError(cb2.args[0][0])
+        assert.deepEqual(cb2.args[0][1], { version: '2.0.0' })
+
+        assert.equal(cb.called, 1)
+        assert.equal(cb2.called, 1)
+      })
     })
-  })
-
-  it('should fetch from correct endpoint', function () {
-    var name = 'some-package'
-    var version = '~1.0.0'
-    resolve(name, version, cb)
-
-    assert.deepEqual(http.get.args[0][0], 'http://registry.npmjs.org/' + name)
-  })
-
-  it('should accept optional callback', function () {
-    var err = new Error()
-    resolve('some-package', '~1.0.0')
-
-    assert.doesNotThrow(function () {
-      httpGet.emit('error', err)
-    })
-  })
-
-  it('should handle HTTP connection error', function () {
-    var err = new Error()
-    resolve('some-package', '~1.0.0', cb)
-    httpGet.emit('error', err)
-    assert.equal(cb.args[0][0], err)
-  })
-
-  it('should handle HTTP error while receiving data', function () {
-    var err = new Error()
-    resolve('some-package', '~1.0.0', cb)
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-    httpResp.emit('data', 'some data')
-    httpResp.emit('error', err)
-    assert.equal(cb.args[0][0], err)
-  })
-
-  it('should handle invalid statusCode', function () {
-    resolve('some-package', '~1.0.0', cb)
-    httpResp.statusCode = 404
-    http.get.args[0][1](httpResp)
-    httpResp.emit('data', '{}')
-    httpResp.emit('end')
-    assert(cb.args[0][0])
-  })
-
-  it('should handle invalid JSON response', function () {
-    resolve('some-package', '~1.0.0', cb)
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-    httpResp.emit('data', 'some data')
-    httpResp.emit('data', 'some more data')
-    httpResp.emit('end')
-    assert(cb.args[0][0] instanceof SyntaxError)
-  })
-
-  it('should validate JSON response schema to have plain object property "versions', function () {
-    resolve('some-package', '~1.0.0', cb)
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-    httpResp.emit('data', JSON.stringify({
-      versions: []
-    }))
-    httpResp.emit('end')
-    assert(cb.args[0][0] instanceof SyntaxError)
-  })
-
-  it('should handle case of no matching version', function () {
-    resolve('some-package', '~5.0.0', cb)
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-    httpResp.emit('data', JSON.stringify({
-      versions: {
-        '0.0.1': {},
-        '1.0.0': {},
-        '2.0.0': {}
-      }
-    }))
-    httpResp.emit('end')
-    assert(cb.args[0][0] instanceof Error)
-  })
-
-  it('should resolve to latest correct version', function () {
-    resolve('some-package', '~1.1.0', cb)
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-    httpResp.emit('data', JSON.stringify({
-      versions: {
-        '0.0.1': { version: '0.0.1' },
-        '1.0.0': { version: '1.0.0' },
-        '1.1.0': { version: '1.1.0' },
-        '2.0.0': { version: '2.0.0' }
-      }
-    }))
-    httpResp.emit('end')
-    assert.ifError(cb.args[0][0])
-    assert.deepEqual(cb.args[0][1], { version: '1.1.0' })
-  })
-
-  it('should properly handle pending requests', function () {
-    var cb2 = mock()
-
-    resolve('some-package', '~1.1.0', cb)
-    resolve('some-package', '~2.0.0', cb2)
-
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-
-    httpResp.emit('data', JSON.stringify({
-      versions: {
-        '0.0.1': { version: '0.0.1' },
-        '1.0.0': { version: '1.0.0' },
-        '1.1.0': { version: '1.1.0' },
-        '2.0.0': { version: '2.0.0' }
-      }
-    }))
-    httpResp.emit('end')
-
-    assert.ifError(cb.args[0][0])
-    assert.ifError(cb2.args[0][0])
-    assert.deepEqual(cb.args[0][1], { version: '1.1.0' })
-    assert.deepEqual(cb2.args[0][1], { version: '2.0.0' })
-  })
-
-  it('should properly cache requests', function () {
-    resolve('some-package', '~1.1.0', cb)
-
-    httpResp.statusCode = 200
-    http.get.args[0][1](httpResp)
-
-    httpResp.emit('data', JSON.stringify({
-      versions: {
-        '0.0.1': { version: '0.0.1' },
-        '1.0.0': { version: '1.0.0' },
-        '1.1.0': { version: '1.1.0' },
-        '2.0.0': { version: '2.0.0' }
-      }
-    }))
-    httpResp.emit('end')
-
-    assert.ifError(cb.args[0][0])
-    assert.deepEqual(cb.args[0][1], { version: '1.1.0' })
-
-    var cb2 = mock()
-    resolve('some-package', '~2.0.0', cb2)
-
-    assert.ifError(cb2.args[0][0])
-    assert.deepEqual(cb2.args[0][1], { version: '2.0.0' })
-
-    assert.equal(cb.called, 1)
-    assert.equal(cb2.called, 1)
   })
 })

--- a/test/unit/resolve.js
+++ b/test/unit/resolve.js
@@ -1,6 +1,6 @@
 /* global describe it beforeEach */
 
-var _ = require('lodash')
+var assign = require('object-assign')
 var proxyquire = require('proxyquire')
 var assert = require('assert')
 var mock = require('mockmock')
@@ -20,7 +20,7 @@ describe('resolve', function () {
         httpResp = new EventEmitter()
         httpGet = new EventEmitter()
         http = { get: mock(httpGet) }
-        var dummyConfig = _.clone(config)
+        var dummyConfig = assign({}, config)
         dummyConfig.registry = protocol + '://registry.npmjs.org/'
         cb = mock()
 


### PR DESCRIPTION
I am trying to use ied with a private registry that is only available over `https`. This PR allows ied to detect and switch between http or https as needed depending on the url

Also I reworked `package.json` to support `npm run lint`