### PR TITLE
fix: wrong test case and Error Type

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -92,7 +92,7 @@ function resolve (name, version, cb) {
     var resolved = pkg.versions[semver.maxSatisfying(Object.keys(pkg.versions), version)]
     if (!resolved) {
       debug('no satisfying version found for %s@%s', name, version)
-      return cb(new Error('No satisfying target found for ' + name + '@' + version), null)
+      return cb(new SyntaxError('No satisfying target found for ' + name + '@' + version), null)
     }
     debug('resolved %s@%s to %s@%s', name, version, resolved.name, resolved.version)
     cb(null, resolved)

--- a/test/unit/resolve.js
+++ b/test/unit/resolve.js
@@ -36,7 +36,7 @@ describe('resolve', function () {
         var version = '~1.0.0'
         resolve(name, version, cb)
 
-        assert.deepEqual(http.get.args[0][0], protocol + '://registry.npmjs.org/' + name)
+        assert.deepEqual(http.get.args[0][0].href, protocol + '://registry.npmjs.org/' + name)
       })
 
       it('should accept optional callback', function () {


### PR DESCRIPTION
- there is a mistake in test case for endpoint check, the test case
  expected href not the reponse object
- switch can not resolve `Error` to `SyntaxError` to meet test case