### PR TITLE
Do not catch errors during callback dispatching

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -45,19 +45,20 @@ function fetch (url, cb) {
 
     res.on('data', function (chunk) { raw += chunk })
     res.on('end', function () {
+      var err = null
+      var parsed
       try {
-        var parsed = JSON.parse(raw)
-        var err = null
+        parsed = JSON.parse(raw)
         if (!parsed.versions || typeof parsed.versions !== 'object') {
           err = new SyntaxError('package.json should have plain object property "versions"')
         }
         if (!err) {
           cache[url] = parsed
         }
-        resolve(err, parsed)
       } catch (e) {
-        resolve(e)
+        err = e
       }
+      resolve(err, parsed)
     })
     res.on('error', resolve)
   }).on('error', resolve)


### PR DESCRIPTION
[Here](https://github.com/alexanderGugel/ied/blob/d3b066f83cff4cd416b142f1b63bb019f43524c6/lib/install_cmd.js#L65) you throw the error is something went wrong. But actually error is being caught and process will keep going and fail later.

I encountered with it when tried to run install command on `package.json` with links on GitHub. I expected to get a proper error message, but just got:

```
TypeError: Cannot read property 'dist' of null
    at expose (/Users/just-boris/coding/ied/lib/expose.js:48:31)
    at /Users/just-boris/coding/ied/node_modules/async/lib/async.js:356:13
```

With this fix, it will be ok

```
Error: No satisfying target found for redux-router@github:just-boris/redux-router
    at /Users/just-boris/coding/ied/lib/resolve.js:84:17
    at resolvePending (/Users/just-boris/coding/ied/lib/resolve.js:15:25)
```