### PR TITLE
User-friendly error output when exiting from the initialization process

### DIFF
--- a/lib/init_cmd.js
+++ b/lib/init_cmd.js
@@ -9,7 +9,12 @@ var home = process.env[isWindows ? 'USERPROFILE' : 'HOME']
 function initCmd (cwd, argv) {
   var initFile = path.resolve(home, '.ied-init')
   init(cwd, initFile, function (err, data) {
-    if (err) throw err
+    if (err && err.message === 'canceled') {
+      console.log('init canceled!')
+      return
+    }
+
+    throw err
   })
 }
 


### PR DESCRIPTION
**before:**
![image](https://cloud.githubusercontent.com/assets/7034281/12399832/5ffba9dc-be2d-11e5-92e5-e93bead057c0.png)

**after:**
![image](https://cloud.githubusercontent.com/assets/7034281/12399835/663dda54-be2d-11e5-9195-9f8e5035a208.png)
