### PR TITLE
Fix error output when exiting from the initialization process

### DIFF
--- a/lib/init_cmd.js
+++ b/lib/init_cmd.js
@@ -9,12 +9,14 @@ var home = process.env[isWindows ? 'USERPROFILE' : 'HOME']
 function initCmd (cwd, argv) {
   var initFile = path.resolve(home, '.ied-init')
   init(cwd, initFile, function (err, data) {
-    if (err && err.message === 'canceled') {
-      console.log('init canceled!')
-      return
-    }
+    if (err) {
+      if (err.message === 'canceled') {
+        console.log('init canceled!')
+        return
+      }
 
-    throw err
+      throw err
+    }
   })
 }
 


### PR DESCRIPTION
Ooops, sorry, but in the current version the error output always.This PR fixes this.