### PR TITLE
Skip root folder for cached tarballs as well as in fetch

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -16,7 +16,7 @@ function read (uid) {
 }
 
 function fetch (dest, uid, cb) {
-  var untar = tar.extract(dest)
+  var untar = tar.extract(dest, {strip: 1})
   read(uid).on('error', cb)
     .pipe(gunzip()).on('error', cb)
     .pipe(untar).on('error', cb)


### PR DESCRIPTION
fixes #59