### PR TITLE
Support non-POSIX shells (#62)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ var config = {
   httpProxy: process.env.IED_HTTP_PROXY || process.env.HTTP_PROXY || null,
   httpsProxy: process.env.IED_HTTPS_PROXY || process.env.HTTPS_PROXY || null,
   requestRetries: 5,
-  sh: process.env.IED_SH || (process.platform === 'win32' ? process.env.comspec || 'cmd' : process.env.SHELL || 'bash'),
+  sh: process.env.IED_SH || (process.platform === 'win32' ? process.env.comspec || 'cmd' : 'bash'),
   shFlag: process.env.IED_SH_FLAG || (process.platform === 'win32' ? '/d /s /c' : '-c')
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ var config = {
   httpProxy: process.env.IED_HTTP_PROXY || process.env.HTTP_PROXY || null,
   httpsProxy: process.env.IED_HTTPS_PROXY || process.env.HTTPS_PROXY || null,
   requestRetries: 5,
-  sh: process.env.IED_SH || (process.platform === 'win32' ? process.env.comspec || 'cmd' : 'bash'),
+  sh: process.env.IED_SH || (process.platform === 'win32' ? process.env.comspec || 'cmd' : 'sh'),
   shFlag: process.env.IED_SH_FLAG || (process.platform === 'win32' ? '/d /s /c' : '-c')
 }
 


### PR DESCRIPTION
#62 — this makes ied work with non-POSIX shells like [fish-shell](http://fishshell.com/).