### PR TITLE
Cache HTTP requests in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules
 
 # Used for debugging
 example
+fixtures

--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ as for example `--save`, `--save-dev`, `--only`, are supported.
   ISSUES:  https://github.com/alexanderGugel/ied/issues
 ```
 
+Development notes
+-----------------
+
+To run the test suite, run `npm test`. The test suite mocks all HTTP requests,
+with fixtures cached inside `fixtures/generated/`. If you make new tests that
+perform HTTP requests, it'll be saved there.
+
+```
+npm test
+```
+
 Credits
 -------
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && rimraf test/integration/node_modules",
     "lint": "standard | snazzy"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
     "path-is-inside": "^1.0.1",
     "proxyquire": "^1.7.3",
     "rimraf": "^2.4.3",
+    "sepia": "^2.0.1",
     "snazzy": "^2.0.1",
     "standard": "^5.3.1",
     "tape": "^4.2.2"
   },
   "scripts": {
-    "test": "mocha --recursive",
+    "test": "mocha",
     "pretest": "npm run lint",
     "lint": "standard | snazzy"
   },

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--require test/setup.js

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+if (!process.env.VCR_MODE) {
+  process.env.VCR_MODE = 'cache'
+}
+
+require('sepia')


### PR DESCRIPTION
Tests are very slow because they simulate `ied install`:

```
  install
    ✓ should install browserify@12.0.1 (19685ms)
    ✓ should install tape@4.2.2 (8569ms)
    ✓ should install express@4.13.3 (16876ms)
    ✓ should install mocha@2.3.4 (4246ms)
    ✓ should install lodash@3.10.1 (4019ms)
    ✓ should install gulp@https://github.com/gulpjs/gulp/archive/4.0.tar.gz (25571ms)
    ✓ should install grunt@0.3.1 (13590ms)
```

This speeds it up _considerably_ by caching HTTP requests:

```
  install
    ✓ should install browserify@12.0.1 (3344ms)
    ✓ should install tape@4.2.2 (420ms)
    ✓ should install express@4.13.3 (613ms)
    ✓ should install mocha@2.3.4 (379ms)
    ✓ should install lodash@3.10.1 (457ms)
    ✓ should install gulp@https://github.com/gulpjs/gulp/archive/4.0.tar.gz (7444ms)
    ✓ should install grunt@0.3.1 (1280ms)
```

This does it by caching the HTTP requests into the repo itself. ~~It comes with 25MB of data~~ Fixtures are .gitignored, so this only affects running the tests locally on your machines.