### PR TITLE
Use resolved package version as uid

### DIFF
--- a/lib/resolvers/npm-registry.js
+++ b/lib/resolvers/npm-registry.js
@@ -64,7 +64,7 @@ module.exports = function resolveFromNpm (name, version, cb) {
     cb(null, {
       name: resolved.name,
       version: resolved.version,
-      uid: packageUid(name, version),
+      uid: packageUid(name, resolved.version),
       shasum: resolved.dist.shasum,
       tarball: resolved.dist.tarball
     })

--- a/test/unit/resolve.js
+++ b/test/unit/resolve.js
@@ -105,7 +105,7 @@ describe('resolve', function () {
             assert.deepEqual(pkg, {
               name: 'some-package',
               version: '1.1.0',
-              uid: 'f379f6f508a68b25ecea93893d69e7daa7f965bf',
+              uid: '9e1e23526b2e08bcd670cd029a18c9e8ea14d916',
               shasum: undefined,
               tarball: undefined
             })


### PR DESCRIPTION
The fix is very small, but can bring a big performance profit.

Consider the following dependency tree:

```
packageA
├── packageB
│   └── packageC (^1.0.0)
└── packageC (1.1.1)
```

Now package uid generated by specified version from package.json. That means that you get different packages as `packageC@^1.0.0` and `packageC@1.1.1` even if it will be resolved to the same version `1.1.1`

After this fix, the resolved version will be used and `packageC` instances will be merged and we will make fewer requests.

