### PR TITLE
resolve dependency version as tag

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -14,8 +14,8 @@ function resolve (name, version, cb) {
   var packageSpec = name + '@' + version
   var pkg = parsePackage(packageSpec)
 
-  if (pkg.type === 'range' || pkg.type === 'version') {
-    resolveFromNpm(name, version, cb)
+  if (pkg.type === 'range' || pkg.type === 'version' || pkg.type === 'tag') {
+    resolveFromNpm(name, version, pkg, cb)
   } else if (pkg.type === 'remote') {
     resolveTarball(name, version, pkg.spec, cb)
   } else if (pkg.type === 'hosted') {

--- a/lib/resolvers/npm-registry.js
+++ b/lib/resolvers/npm-registry.js
@@ -43,10 +43,11 @@ function fetch (url, cb) {
   })
 }
 
-module.exports = function resolveFromNpm (name, version, cb) {
+module.exports = function resolveFromNpm (name, version, pkg, cb) {
   // Scoped module
   var isScopedModule = name.charAt(0) === '@'
   var escapedName = isScopedModule ? '@' + encodeURIComponent(name.substr(1)) : encodeURIComponent(name)
+  var packageType = pkg.type
 
   fetch(url.resolve(config.registry, escapedName), function (err, pkg) {
     if (err) {
@@ -56,7 +57,15 @@ module.exports = function resolveFromNpm (name, version, cb) {
     if (!pkg.versions || typeof pkg.versions !== 'object') {
       return cb(new SyntaxError('package.json should have plain object property "versions"'))
     }
-    var resolved = pkg.versions[semver.maxSatisfying(Object.keys(pkg.versions), version)]
+    var resolved
+    if (packageType === 'tag') {
+      if (!pkg['dist-tags'] || typeof pkg['dist-tags'] !== 'object') {
+        return cb(new SyntaxError('expected to have package with tagged versions'))
+      }
+      resolved = pkg.versions[pkg['dist-tags'][version]]
+    } else {
+      resolved = pkg.versions[semver.maxSatisfying(Object.keys(pkg.versions), version)]
+    }
     if (!resolved) {
       debug('no satisfying version found for %s@%s', name, version)
       return cb(new Error('No satisfying target found for ' + name + '@' + version), null)

--- a/test/unit/resolve.js
+++ b/test/unit/resolve.js
@@ -113,6 +113,35 @@ describe('resolve', function () {
           })
         })
 
+        it('should resolve tag to version', function (done) {
+          server.get('/some-package').reply(200, {
+            'dist-tags': {
+              latest: '1.0.0'
+            },
+            versions: {
+              '0.0.1': { version: '0.0.1' },
+              '1.0.0': { version: '1.0.0', dist: {} }
+            }
+          })
+          resolve('some-package', 'latest', function (err, pkg) {
+            assert.ifError(err)
+            assert.equal(pkg.version, '1.0.0')
+            done()
+          })
+        })
+
+        it('should handle missing dist-tag', function (done) {
+          server.get('/some-package').reply(200, {
+            versions: {
+              '0.0.1': { version: '0.0.1' }
+            }
+          })
+          resolve('some-package', 'latest', function (err, pkg) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+
         it('should properly handle pending requests', function (doneAll) {
           var pendingRequests = 2
           function done () {
@@ -191,18 +220,11 @@ describe('resolve', function () {
     var resolve
 
     beforeEach(function () {
-      resolve = require('../../lib/resolve')
+      resolve = proxyquire('../../lib/resolve', {})
     })
 
     it('should report that github is not supported now', function (done) {
       resolve('some-package', 'alexanderGugel/ied', function (err) {
-        assert(err)
-        done()
-      })
-    })
-
-    it('should throw on unknown version spec', function (done) {
-      resolve('some-package', 'unknown spec', function (err) {
         assert(err)
         done()
       })


### PR DESCRIPTION
now `ied install babel-core@latest` is supported

closes #74 
