### PR TITLE
Invoke postinstallation hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: node_js
+env:
+    - CXX=g++-4.8
+addons:
+    apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.8
+
 node_js:
   - "4.1"
   - "4.0"

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ module.exports = {
   pingCmd: require('./ping_cmd'),
   progress: require('./progress'),
   resolve: require('./resolve'),
+  run: require('./run'),
   runCmd: require('./run_cmd'),
   save: require('./save'),
   shellCmd: require('./shell_cmd'),

--- a/lib/install.js
+++ b/lib/install.js
@@ -33,6 +33,13 @@ function linkPkg (dir, pkg, cb) {
 // Invoke lifecycle scripts, such as postinstall
 function invokeScripts (dir, cb) {
   var pkg = require(path.join(dir, 'package.json'))
+  var files = fs.readdirSync(dir)
+  if (!pkg.scripts) {
+    pkg.scripts = {}
+  }
+  if (files.indexOf('binding.gyp') > -1 && !pkg.scripts.preinstall) {
+    pkg.scripts.preinstall = 'node-gyp rebuild'
+  }
   run(dir, pkg, 'install', cb)
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -10,6 +10,7 @@ var uuid = require('node-uuid')
 var forceSymlink = require('force-symlink')
 var resolve = require('./resolve')
 var fetch = require('./fetch')
+var run = require('./run')
 var locks = require('./locks')
 
 // Exposes the dependency defined via pkg to the package defined via its root
@@ -27,6 +28,12 @@ function linkPkg (dir, pkg, cb) {
     mkdirp.bind(null, path.join(dir, 'node_modules', path.dirname(pkg.name))),
     forceSymlink.bind(null, srcPath, dstPath)
   ], cb)
+}
+
+// Invoke lifecycle scripts, such as postinstall
+function invokeScripts (dir, cb) {
+  var pkg = require(path.join(dir, 'package.json'))
+  run(dir, pkg, 'install', cb)
 }
 
 // Reads package.json file from the given directory
@@ -116,7 +123,10 @@ function handleResolvedPkg (dir, pkg, cb) {
       // Completes the installation. This step needs to be "as atomic as
       // possible" to ensure that our node_modules is always consistent on a
       // package level.
-      fs.rename.bind(null, tmpDest, finalDest)
+      fs.rename.bind(null, tmpDest, finalDest),
+
+      // Invoke postinstall scripts
+      invokeScripts.bind(null, finalDest)
     ], function (err) {
       cb(err, pkg)
     })

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,0 +1,37 @@
+var path = require('path')
+var async = require('async')
+var config = require('./config')
+var child_process = require('child_process')
+var assign = require('object-assign')
+
+function runCommand (cwd, command, cb) {
+  var env = assign({}, process.env, {
+    PATH: [
+      path.join(cwd, 'node_modules/.bin'), process.env.PATH
+    ].join(path.delimiter)
+  })
+  var childProcess = child_process.spawn(config.sh, [config.shFlag, command], {
+    cwd: cwd,
+    env: env,
+    stdio: 'inherit'
+  })
+  childProcess.on('close', function (code) {
+    cb(code ? new Error('Command ' + command + ' ended with code ' + code) : null)
+  })
+  childProcess.on('error', cb)
+}
+
+module.exports = function (cwd, pkg, script, cb) {
+  var scripts = [
+    'pre' + script,
+    script,
+    'post' + script
+  ].map(function (scriptName) {
+    return pkg.scripts && pkg.scripts[scriptName]
+  }).filter(function (script) {
+    return script
+  })
+  async.series(scripts.map(function (script) {
+    return runCommand.bind(null, cwd, script)
+  }), cb)
+}

--- a/lib/run_cmd.js
+++ b/lib/run_cmd.js
@@ -2,9 +2,7 @@
 
 var path = require('path')
 var async = require('async')
-var config = require('./config')
-var child_process = require('child_process')
-var assign = require('object-assign')
+var run = require('./run')
 
 function runCmd (cwd, argv) {
   var scripts = argv._.slice(1)
@@ -16,21 +14,8 @@ function runCmd (cwd, argv) {
     return
   }
 
-  var env = assign({}, process.env, {
-    PATH: [
-      path.join(cwd, 'node_modules/.bin'), process.env.PATH
-    ].join(path.delimiter)
-  })
-
   async.mapSeries(scripts, function execScript (scriptName, cb) {
-    var scriptCmd = pkg.scripts[scriptName]
-    if (!scriptCmd) return cb(null, null)
-    var childProcess = child_process.spawn(config.sh, [config.shFlag, scriptCmd], {
-      env: env,
-      stdio: 'inherit'
-    })
-    childProcess.on('close', cb.bind(null, null))
-    childProcess.on('error', cb)
+    run(cwd, pkg, scriptName, cb)
   }, function (err, statuses) {
     if (err) throw err
     var info = scripts.map(function (script, i) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "sepia": "^2.0.1",
     "snazzy": "^2.0.1",
     "standard": "^5.3.1",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "tmp": "0.0.28"
   },
   "scripts": {
     "test": "mocha",

--- a/test/integration/install.js
+++ b/test/integration/install.js
@@ -17,7 +17,8 @@ describe('install', function () {
     { name: 'mocha', version: '2.3.4', checkCli: true },
     { name: 'lodash', version: '3.10.1', checkCli: false },
     { name: 'gulp', version: 'https://github.com/gulpjs/gulp/archive/4.0.tar.gz', checkCli: true },
-    { name: 'grunt', version: '0.3.1', checkCli: true }
+    { name: 'grunt', version: '0.3.1', checkCli: true },
+    { name: 'electron-prebuilt', version: '0.36.8', checkCli: false }
   ]
 
   function reset (done) {

--- a/test/integration/install.js
+++ b/test/integration/install.js
@@ -18,7 +18,8 @@ describe('install', function () {
     { name: 'lodash', version: '3.10.1', checkCli: false },
     { name: 'gulp', version: 'https://github.com/gulpjs/gulp/archive/4.0.tar.gz', checkCli: true },
     { name: 'grunt', version: '0.3.1', checkCli: true },
-    { name: 'electron-prebuilt', version: '0.36.8', checkCli: false }
+    { name: 'electron-prebuilt', version: '0.36.8', checkCli: false },
+    { name: 'bufferutil', version: '1.2.1', checkCli: false }
   ]
 
   function reset (done) {

--- a/test/unit/install.js
+++ b/test/unit/install.js
@@ -5,29 +5,90 @@
 var proxyquire = require('proxyquire')
 var assert = require('assert')
 var mock = require('mockmock')
+var fs = require('fs')
+var tmp = require('tmp')
 
 describe('install', function () {
-  var forceSymlink
   var resolve
   var fetch
+  var run
   var install
-  var cb
+  var tmpDir
+  var registryMock
 
   beforeEach(function () {
-    forceSymlink = mock()
-    resolve = mock()
-    fetch = mock()
-    cb = mock()
-
+    tmpDir = tmp.dirSync().name
+    resolve = mock(function (name, version, cb) {
+      cb(null, {
+        name: name,
+        version: version,
+        uid: name + '-' + version
+      })
+    })
+    registryMock = {}
+    fetch = mock(function (dest, tarball, uid, shasum, cb) {
+      var err
+      try {
+        fs.writeFileSync(dest + '/package.json', JSON.stringify(registryMock[uid]), 'utf8')
+      } catch (e) {
+        err = e
+      }
+      cb(err)
+    })
+    run = mock(function (dir, pkg, cmd, cb) { cb(null) })
     install = proxyquire('../../lib/install', {
-      'force-symlink': forceSymlink,
       './resolve': resolve,
+      './run': run,
       './fetch': fetch
     })
   })
 
-  it('should resolve correct package', function () {
-    install('/somewhere/', 'name', '~1.0.0', false, cb)
-    assert.deepEqual(resolve.args[0].slice(0, 2), ['name', '~1.0.0'])
+  it('should install package without dependencies', function (done) {
+    registryMock['name-1.0.0'] = {
+      dependencies: {}
+    }
+    install(tmpDir, 'name', '1.0.0', function (err) {
+      assert.ifError(err)
+      assert.equal(fetch.args[0][2], 'name-1.0.0')
+      done()
+    })
+  })
+
+  it('should handle different package versions in dependency tree', function (done) {
+    registryMock['name-1.0.0'] = {
+      dependencies: {
+        child: '0.0.1',
+        common: '1.0.0'
+      }
+    }
+    registryMock['child-0.0.1'] = {
+      dependencies: {
+        common: '2.0.0'
+      }
+    }
+    registryMock['common-1.0.0'] = {}
+    registryMock['common-2.0.0'] = {}
+    install(tmpDir, 'name', '1.0.0', function (err) {
+      assert.ifError(err)
+      assert.equal(fetch.args[0][2], 'name-1.0.0')
+      assert.equal(fetch.args[1][2], 'child-0.0.1')
+      assert.equal(fetch.args[2][2], 'common-1.0.0')
+      assert.equal(fetch.args[3][2], 'common-2.0.0')
+      done()
+    })
+  })
+
+  it('should invoke post installation scripts', function (done) {
+    registryMock['name-1.0.0'] = {
+      dependencies: {},
+      scripts: {
+        install: 'echo "installed"'
+      }
+    }
+    install(tmpDir, 'name', '1.0.0', function (err) {
+      assert.ifError(err)
+      assert.deepEqual(run.args.length, 1)
+      done()
+    })
   })
 })


### PR DESCRIPTION
closes #82
Also, this feature was asked in #43 as the necessary thing to install `electron-prebuilt`.

It is not ready to merge, yet, I'd like just share my results, and I want to add more tests before this will be merged.


And there is a thing with native packages. They require `node-gyp` to be installed. NPM carries bundled `node-gyp` command. To get this work with IED, we need to install it: `npm install -g node-gyp`. Maybe it should be mentioned in the docs.