### PR TITLE
Fix travis badge in README to show status of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ied
 ===
 
-[![Travis](https://img.shields.io/travis/alexanderGugel/ied.svg)](https://travis-ci.org/alexanderGugel/ied)
+[![Travis](https://img.shields.io/travis/alexanderGugel/ied/master.svg)](https://travis-ci.org/alexanderGugel/ied)
 [![npm](https://img.shields.io/npm/v/ied.svg)](https://www.npmjs.com/package/ied)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 [![Join the chat at https://gitter.im/migme/beachball](https://img.shields.io/badge/gitter-join%20chat-brightgreen.svg)](https://gitter.im/alexanderGugel/ied)


### PR DESCRIPTION
The URL should specify the branch name, otherwise the image shows the status of the latest build which happened to run on Travis, which can be from any other branch.

---

That's why it currently shows as failing - because it's picking up your rebirth branch.