### PR TITLE
Use junction as symlink type on Windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,8 +13,9 @@ function Config (process) {
   this.httpProxy = process.env.IED_HTTP_PROXY || process.env.HTTP_PROXY || null
   this.httpsProxy = process.env.IED_HTTPS_PROXY || process.env.HTTPS_PROXY || null
   this.requestRetries = parseInt(process.env.IED_REQUEST_RETRIES, 10) || 5
-  this.sh = process.env.IED_SH || (process.platform === 'win32' ? process.env.comspec || 'cmd' : 'sh')
-  this.shFlag = process.env.IED_SH_FLAG || (process.platform === 'win32' ? '/d /s /c' : '-c')
+  this.sh = process.env.IED_SH || (isWindows ? process.env.comspec || 'cmd' : 'sh')
+  this.shFlag = process.env.IED_SH_FLAG || (isWindows ? '/d /s /c' : '-c')
+  this.symlinkType = isWindows ? 'junction' : 'file'
 }
 
 module.exports = new Config(process)

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -5,6 +5,7 @@ var path = require('path')
 var forceSymlink = require('force-symlink')
 var debug = require('./debuglog')('expose')
 var fs = require('fs')
+var config = require('./config')
 
 // Finally symlink if dependency is being installed as an entry.
 // Entry dependencies can be required by its name.
@@ -13,7 +14,7 @@ function symlinkEntry (dir, pkg, cb) {
   var dirname = path.dirname(pkg.name)
   var srcPath = path.relative(dirname, pkg.uid)
   debug('linking (entry) %s -> %s', srcPath, dstPath)
-  forceSymlink(srcPath, dstPath, cb)
+  forceSymlink(srcPath, dstPath, config.symlinkType, cb)
 }
 
 var binMode = parseInt('0777', 8) & (~process.umask())
@@ -32,7 +33,7 @@ function symlinkScripts (dir, pkg, cb) {
     var dstPath = path.join(dir, '.bin', name)
     debug('linking (bin) %s -> %s', srcPath, dstPath)
     async.series([
-      forceSymlink.bind(null, srcPath, dstPath),
+      forceSymlink.bind(null, srcPath, dstPath, config.symlinkType),
       fs.chmod.bind(null, path.resolve(srcPath, dstPath), binMode)
     ], cb)
   }, cb)

--- a/lib/install.js
+++ b/lib/install.js
@@ -11,6 +11,7 @@ var forceSymlink = require('force-symlink')
 var resolve = require('./resolve')
 var fetch = require('./fetch')
 var locks = require('./locks')
+var config = require('./config')
 
 // Exposes the dependency defined via pkg to the package defined via its root
 // directory `dir`. Correctly handles scoped modules.
@@ -25,7 +26,7 @@ function linkPkg (dir, pkg, cb) {
   // path.dirname('world') #=> '.'
   async.series([
     mkdirp.bind(null, path.join(dir, 'node_modules', path.dirname(pkg.name))),
-    forceSymlink.bind(null, srcPath, dstPath)
+    forceSymlink.bind(null, srcPath, dstPath, config.symlinkType)
   ], cb)
 }
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -35,7 +35,7 @@ function linkToGlobal (cwd, cb) {
     var srcPath = symlink[0]
     var dstPath = symlink[1]
     console.log(dstPath, '->', srcPath)
-    forceSymlink(srcPath, dstPath, cb)
+    forceSymlink(srcPath, dstPath, config.symlinkType, cb)
   }, cb)
 }
 
@@ -47,7 +47,7 @@ function linkFromGlobal (cwd, name, cb) {
   var dstPath = path.join(cwd, 'node_modules', name)
   var srcPath = path.join(config.globalNodeModules, name)
   console.log(dstPath, '->', srcPath)
-  forceSymlink(srcPath, dstPath, cb)
+  forceSymlink(srcPath, dstPath, config.symlinkType, cb)
 }
 
 // Used for `ied unlink`.


### PR DESCRIPTION
The default folder symlink requires elevated permissions to work on
Windows. By using junctions we can remove this requirement and work
functionally the same way.

This should resolve the issue in #35