### PR TITLE
Add `start`, `build` and `stop` as `ied run` aliases

### DIFF
--- a/USAGE.txt
+++ b/USAGE.txt
@@ -16,6 +16,10 @@ The commands are:
   init        initialize a new package
   link        link the current package or into it
   unlink      unlink the current package or from it
+  start       runs `ied run start`
+  stop        runs `ied run stop`
+  build       runs `ied run build`
+  test        runs `ied run test`
 
 Flags:
   -h, --help      show usage information

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -67,6 +67,9 @@ if (argv.registry) {
       break
     case 't':
     case 'test':
+    case 'start':
+    case 'build':
+    case 'stop':
       runCmd = require('./run_cmd').default
       const _argv = Object.create(argv)
       _argv._ = ['run'].concat(argv._)


### PR DESCRIPTION
Adds npm-like aliases for `start`, `build` and `stop`. I also added these sub-commands to `USAGE.txt` (and the already existing `test` sub-command), but there's not much to say about them, so what's your take on including them?