### PR TITLE
Add progress bar for downloads and log levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "object-assign": "^3.0.0",
     "object.entries": "^1.0.3",
     "ora": "^0.2.1",
+    "progress": "1.1.8",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.2",
     "semver": "^5.0.1",

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -12,7 +12,9 @@ const argv = minimist(process.argv.slice(2), {
     D: 'save-dev',
     o: 'only',
     r: 'registry',
-    b: 'build'
+    b: 'build',
+    d: 'debug',
+    v: 'verbose'
   }
 })
 


### PR DESCRIPTION
- Adds a progress bar for HTTP downloads similar to what `master` has
- Adds a `-v, --verbose` option to show `Install package@version`
  (disables progress bar)
- Adds a `-d, --debug` option to show (in addition to the above) the
  current `resolve` output

Currently we pass the specified log level to the functions that need it, which isn't "scalable" when more logging is added, so we might want to consider something better suited. Would you rather we look at that right away or rather delay until necessary?

What do you think about the way to specify log level through such command line arguments? To me it's a very appealing approach, because it provides a nice and descriptive way to provide a certain log level. If we end up with something like this, we could document the options along with how they affect log level in `-h`.