### PR TITLE
Replace per module download progress with progress reporting over the whole process

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import minimist from 'minimist'
+import ProgressBar from 'progress'
 import * as config from './config'
 
 const cwd = process.cwd()
@@ -20,6 +21,14 @@ const argv = minimist(process.argv.slice(2), {
 
 if (argv.registry) {
   config.registry = argv.registry
+}
+
+if (argv.verbose) {
+  config.logLevel = 'verbose'
+}
+
+if (argv.debug) {
+  config.logLevel = 'debug'
 }
 
 // This doesn't have to be an IIFE, since Node wraps everything in a function
@@ -53,8 +62,15 @@ if (argv.registry) {
   switch (subCommand) {
     case 'i':
     case 'install':
+      let progress
+      if (!config.logLevel) {
+        progress = new ProgressBar(':percent    :current / :total   installing modules', { total: 1 })
+      }
+
       installCmd = require('./install_cmd').default
-      installCmd(cwd, argv).subscribe()
+      installCmd(cwd, argv, config.logLevel, progress).subscribe(null, null, () => {
+        progress && progress.tick()
+      })
       break
     case 'sh':
     case 'shell':

--- a/src/install_cmd.js
+++ b/src/install_cmd.js
@@ -41,7 +41,7 @@ export default function installCmd (cwd, argv) {
     ? entryDep.fromArgv(cwd, argv)
     : entryDep.fromFS(cwd)
 
-  const resolved = updatedPkgJSONs::install.resolveAll(progress, cwd, progress)::skip(1)
+  const resolved = updatedPkgJSONs::install.resolveAll(progress, cwd)::skip(1)
     ::filter(({ local }) => !local)
     ::_do(logResolved.bind(null, logLevel))
     ::publishReplay().refCount()

--- a/src/install_cmd.js
+++ b/src/install_cmd.js
@@ -1,5 +1,4 @@
 import path from 'path'
-import ProgressBar from 'progress'
 import {EmptyObservable} from 'rxjs/observable/EmptyObservable'
 import {_do} from 'rxjs/operator/do'
 import {concat} from 'rxjs/operator/concat'
@@ -27,16 +26,7 @@ function logResolved (logLevel, {parentTarget, pkgJSON: {name, version}, target}
  * @return {Observable} - an observable sequence that will be completed once
  * the installation is complete.
  */
-export default function installCmd (cwd, argv) {
-  let logLevel = false
-  if (argv.debug) logLevel = 'debug'
-  if (argv.verbose) logLevel = 'info'
-
-  let progress
-  if (!logLevel) {
-    progress = new ProgressBar(':percent    :current / :total   installing modules', { total: 1 })
-  }
-
+export default function installCmd (cwd, argv, logLevel, progress) {
   const explicit = !!(argv._.length - 1)
   const updatedPkgJSONs = explicit
     ? entryDep.fromArgv(cwd, argv)
@@ -55,9 +45,6 @@ export default function installCmd (cwd, argv) {
     ? resolved::install.buildAll()
     : EmptyObservable.create()
 
-  const merged = fsCache.init()
+  return fsCache.init()
     ::concat(linked::merge(fetched)::concat(built))
-
-  merged.subscribe(null, null, () => progress && progress.tick())
-  return merged
 }

--- a/src/install_cmd.js
+++ b/src/install_cmd.js
@@ -33,7 +33,7 @@ export default function installCmd (cwd, argv) {
 
   let progress
   if (!logLevel) {
-    progress = new ProgressBar(':percent    :current / :total', { total: 1 })
+    progress = new ProgressBar(':percent    :current / :total   installing modules', { total: 1 })
   }
 
   const explicit = !!(argv._.length - 1)


### PR DESCRIPTION
Shows progress similarly to how webpack does, and shows it for the whole installation process instead of individual dependencies. Looks like this:

![patch](https://cldup.com/TiInsle_Xr.gif)

Doesn't look like it affects permformance very radically. I'm looking at a difference between 

```
ied i  1.44s user 0.37s system 80% cpu 2.253 total
```

and 

```
ied i  1.11s user 0.27s system 57% cpu 2.393 total
```

In short, it's implemented so that for every module we resolve we increment the total amount we need to install. For every resolved local module or fetched module we increment the count for modules that are ready. This is abstracted by `.total` and `.tick()` in the `progress` package. It also provides the formatting we use to display progress.