### PR TITLE
Support scoped modules

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -29,7 +29,12 @@ export function validatePackageRoot (uri, body) {
  * the package root.
  */
 export function httpGetPackageRoot (name) {
-  const uri = url.resolve(config.registry, name)
+  const isScoped = name.charAt(0) === '@'
+  const escapedName = isScoped
+    ? '@' + encodeURIComponent(name.substr(1))
+    : encodeURIComponent(name)
+
+  const uri = url.resolve(config.registry, escapedName)
   const cached = imCache.get(uri)
   if (cached) return cached
   const result = httpGetJSON(uri)


### PR DESCRIPTION
Reapply functionality in https://github.com/alexanderGugel/ied/blob/fde1311d495bb935fd926189d13523c3c5fd35a4/lib/resolvers/npm-registry.js#L50

Based on some testing and a browse through the linking code in `rebirth`, it should handle scoped modules just fine with this addition (and the folder structure in my tests is looking good).