### PR TITLE
Init `fs_cache` upon `install_cmd` call

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -54,7 +54,7 @@ if (argv.registry) {
     case 'i':
     case 'install':
       installCmd = require('./install_cmd').default
-      installCmd(cwd, argv).subscribe()
+      installCmd(cwd, argv, (obs) => obs.subscribe())
       break
     case 'sh':
     case 'shell':


### PR DESCRIPTION
I solved this by adding a subscribe to of the `fs_cache` init's `_mkdirp` observable. The downside is that we need to change the `install_cmd` exported function signature. Would it be ok? Could this be done better?