### PR TITLE
Add inline source maps to compiled lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,4 @@ dev:
 	$(DEPS_BIN_DIR)/mocha test/*-test.js $(MOCHA_FLAGS) --watch
 
 watch:
-	$(DEPS_BIN_DIR)/babel -w src --out-dir lib
+	NODE_ENV=development $(DEPS_BIN_DIR)/babel -w src --out-dir lib -s inline

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ora": "^0.2.1",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.2",
+    "source-map-support": "^0.4.0",
     "tar-fs": "^1.8.1",
     "xtend": "^4.0.1"
   },

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -2,6 +2,9 @@
 
 import minimist from 'minimist'
 import * as config from './config'
+if (process.env.NODE_ENV === 'development') {
+	require('source-map-support').install()
+}
 
 const alias = {
 	h: 'help',
@@ -123,4 +126,3 @@ let cacheCmd
 			helpCmd().subscribe()
 	}
 })()
-


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to ied. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make test`.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test.

Finally, read through our contributors guide and make adjustments as necessary.
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] a test is included
- [X] documentation is changed or added
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

Babel Compilation


##### Description of change

Added inline sourcemaps to the lib built files to get proper stack traces:

from:
```
/Users/olivier/Developer/nodejs/ied/ied/lib/registry.js:97
  _assert2.default.equal(statusCode, 200, 'error status code ' + uri + ': ' + error);
                   ^
AssertionError: error status code https://registry.npmjs.org/eslint/node_modules/eslint: undefined
    at checkStatus (/Users/olivier/Developer/nodejs/ied/ied/lib/registry.js:97:20)
    at SafeSubscriber._next (/Users/olivier/Developer/nodejs/ied/ied/lib/registry.js:134:12)
    at SafeSubscriber.__tryOrSetError (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:247:10)
    at SafeSubscriber.next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:191:23)
    at Subscriber._next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:135:22)
    at Subscriber.next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:95:12)
    at DoSubscriber._next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/operator/do.ts:93:20)
```

to:
```
../src/registry.js:48
	assert.equal(statusCode, 200, `error status code ${uri}: ${error}`)
        ^
AssertionError: error status code https://registry.npmjs.org/supertest/node_modules/supertest: undefined
    at checkStatus (../src/registry.js:48:9)
    at SafeSubscriber._next (../src/registry.js:80:19)
    at SafeSubscriber.__tryOrSetError (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:247:10)
    at SafeSubscriber.next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:191:23)
    at Subscriber._next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:135:22)
    at Subscriber.next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:95:12)
    at DoSubscriber._next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/operator/do.ts:93:20)
    at DoSubscriber.Subscriber.next (/Users/olivier/Developer/nodejs/ied/ied/node_modules/rxjs/src/Subscriber.ts:95:12)
    at ../src/util.js
```