### PR TITLE
Add configurable storage directory that defaults to `node_modules/.ca…

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -59,13 +59,13 @@ export function build (nodeModules, dep) {
 		const env = {npm_execpath: '', ...process.env}
 
 		env.PATH = [
-			path.join(nodeModules, target, 'node_modules', '.bin'),
+			path.join(config.storageDir, target, 'node_modules', '.bin'),
 			path.resolve(__dirname, '..', 'node_modules', '.bin'),
 			process.env.PATH
 		].join(path.delimiter)
 
 		const childProcess = spawn(config.sh, [config.shFlag, script], {
-			cwd: path.join(nodeModules, target, 'package'),
+			cwd: path.join(config.storageDir, target, 'package'),
 			env,
 			stdio: 'inherit'
 			// shell: true // does break `dtrace-provider@0.6.0` build

--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,14 @@ export const registry = env.IED_REGISTRY || 'https://registry.npmjs.org/'
 export const cacheDir = env.IED_CACHE_DIR || path.join(home, '.ied_cache')
 
 /**
+ * directory used for locally installed `node_modules`.
+ * configurable via `IED_STORAGE_DIR`, default to `node_modules/.cas`
+ * @type {String}
+ */
+export const storageDir = env.IED_STORAGE_DIR ||
+  path.join('node_modules', '.cas')
+
+/**
  * directory used for globally installed `node_modules`.
  * configurable via `IED_GLOBAL_NODE_MODULES`, default to `.node_modules` in
  * the user's home directory.

--- a/src/install_cmd.js
+++ b/src/install_cmd.js
@@ -11,6 +11,7 @@ import {resolveAll, fetchAll, linkAll} from './install'
 import {init as initCache} from './cache'
 import {fromArgv, fromFs, save} from './pkg_json'
 import {buildAll} from './build'
+import * as config from './config'
 
 /**
  * run the installation command.
@@ -24,9 +25,10 @@ export default function installCmd (cwd, argv) {
 	const updatedPkgJSONs = isExplicit ? fromArgv(cwd, argv) : fromFs(cwd)
 
 	const nodeModules = path.join(cwd, 'node_modules')
+	const target = path.relative(config.storageDir, '.')
 
 	const resolvedAll = updatedPkgJSONs
-		::map((pkgJson) => ({pkgJson, target: '..'}))
+		::map((pkgJson) => ({pkgJson, target, isEntry: true}))
 		::resolveAll(nodeModules, undefined, isExplicit)::skip(1)
 		::publishReplay().refCount()
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to ied. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make test`.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test.

Finally, read through our contributors guide and make adjustments as necessary.
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] a test is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

- `install`
- `build`

##### Description of change

Added a new config variable: `env.IED_STORAGE_DIR`

That defaults to `node_modules/.cas`.

Basically this enables us to address #96 and get a very clean folder layout (way friendlier for web-based IDEs!).

I like it as it really gives a cleaner result after an install, really shines vs. npm@3. So I think we could use a subfolder by default (`.cas`). However if you'd rather keep things the way they are, I'll gladly revert the default (while keeping it configurable by an environment var). 
