### PR TITLE
Refactor hosted resolve to support multiple providers, add bitbucket …

### DIFF
--- a/test/e2e/install.e2e.js
+++ b/test/e2e/install.e2e.js
@@ -23,12 +23,14 @@ const buildTargets = [
 	'dtrace-provider'
 ]
 
-const fileTargets = [
+const localTargets = [
 	'mocha@file:../../../node_modules/mocha'
 ]
 
-const githubTargets = [
-	'gulp@github:gulpjs/gulp#4.0'
+const hostedTargets = [
+	'gulp@github:gulpjs/gulp#4.0',
+	'double-ended-queue@git+https://github.com/petkaantonov/deque.git',
+	'bitbucket-api@git+https://bitbucket.org/hgarcia/node-bitbucket-api.git'
 ]
 
 const base = path.join(__dirname, '../../.tmp/test')
@@ -110,8 +112,8 @@ describe('e2e install & build', () => {
 	})
 })
 
-describe('e2e `file:` install', () => {
-	fileTargets.forEach((target) => {
+describe('e2e local install', () => {
+	localTargets.forEach((target) => {
 		describe(`ied install ${target}`, function () {
 			const [name] = target.split('@')
 			const cwd = path.join(base, name)
@@ -149,8 +151,8 @@ describe('e2e `file:` install', () => {
 	})
 })
 
-describe('e2e `github:` install', () => {
-	githubTargets.forEach((target) => {
+describe('e2e hosted install', () => {
+	hostedTargets.forEach((target) => {
 		describe(`ied install ${target}`, function () {
 			const [name] = target.split('@')
 			const cwd = path.join(base, name)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to ied. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make test`.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test.

Finally, read through our contributors guide and make adjustments as necessary.
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] a test is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

- `install`


##### Description of change

Refactored github support to be more generic. Dropped the specific GitHub API call to fetch a commit hash associated with a branch to prevent dealing with rejections (too many requests).

Instead, I directly hashed the given directUrl from `npa`. We loose auto commit-tracking (must rm -rf and reinstall since hash won't change while content might) but we get an easier broader support (bitbucket and basically any host that provides tarballs). 