### PR TITLE
Add support for private registries

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "node-uuid": "^1.4.7",
     "npm-package-arg": "^4.2.0",
     "ora": "^0.2.3",
+    "registry-auth-token": "^2.1.0",
     "rimraf": "^2.5.3",
     "rxjs": "^5.0.0-beta.9",
     "semver": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.10.2",
     "mocha": "^2.5.3",
+    "nock": "^8.0.0",
     "nyc": "^6.6.1",
+    "proxyquire": "^1.7.10",
     "resolve": "^1.1.7",
     "rimraf": "^2.5.3",
     "sinon": "^1.17.4"

--- a/src/install.js
+++ b/src/install.js
@@ -18,6 +18,7 @@ import needle from 'needle'
 import assert from 'assert'
 import npa from 'npm-package-arg'
 import memoize from 'lodash.memoize'
+import getRegistryUrl from 'registry-auth-token/registry-url'
 
 import * as cache from './cache'
 import * as config from './config'
@@ -148,9 +149,17 @@ export function resolveRemote (nodeModules, parentTarget, name, version, isExpli
  * @return {Observable} - observable sequence of `package.json` objects.
  */
 export function resolveFromNpm (nodeModules, parentTarget, parsedSpec) {
-	const {raw, name, type, spec} = parsedSpec
+	const {raw, name, type, spec, scope} = parsedSpec
+	const registryUrl = getRegistryUrl(scope)
+	const requestOptions = {
+		headers: util.authHeadersForUrl(registryUrl),
+		retries: config.retries,
+		registry: registryUrl,
+		legacyMode: registryUrl !== registry.DEFAULT_REGISTRY
+	}
+
 	log(`resolving ${raw} from npm`)
-	const options = {...config.httpOptions, retries: config.retries}
+	const options = {...config.httpOptions, ...requestOptions}
 	return registry.match(name, spec, options)::map((pkgJson) => {
 		const target = pkgJson.dist.shasum
 		log(`resolved ${raw} to tarball shasum ${target} from npm`)
@@ -365,7 +374,8 @@ function download (tarball, expected, type) {
 	log(`downloading ${tarball}, expecting ${expected}`)
 	return Observable.create((observer) => {
 		const shasum = crypto.createHash('sha1')
-		const response = needle.get(tarball, config.httpOptions)
+		const headers = util.authHeadersForUrl(tarball)
+		const response = needle.get(tarball, {...config.httpOptions, headers})
 		const cached = response.pipe(cache.write())
 
 		const errorHandler = (error) => observer.error(error)

--- a/test/spec/install.spec.js
+++ b/test/spec/install.spec.js
@@ -1,0 +1,48 @@
+import assert from 'assert'
+import nock from 'nock'
+import {resolveFromNpm} from '../../src/install'
+import {DEFAULT_REGISTRY} from '../../src/registry'
+import proxyquire from 'proxyquire'
+
+describe('install', () => {
+	describe('resolveFromNpm', () => {
+		it('should resolve package to the correct sha sum', done => {
+			const shasum = '2e2f3ff96b54d1e3fecceebf0498691054dfce0f'
+			nock(DEFAULT_REGISTRY).get('/ied/%5E2.1.0').reply(200, {dist: {shasum}})
+
+			resolveFromNpm(__dirname, __dirname, {name: 'ied', spec: '^2.1.0'}).subscribe(res => {
+				assert.equal(res.target, shasum)
+				done()
+			})
+		})
+
+		it('should use configured registry and auth token for scope', done => {
+			const shasum = 'shasum'
+			const path = __dirname
+			nock('https://foo.bar', {
+				reqheaders: {
+					authorization: 'Bearer some-token'
+				}
+			}).get('/@rexxars%2Fied').reply(200, {
+				versions: {
+					'2.1.0': {
+						dist: {shasum}
+					}
+				}
+			})
+
+			function tokenStub () {
+				return 'some-token'
+			}
+			tokenStub['@global'] = true
+
+			proxyquire('../../src/install', {
+				'registry-auth-token/registry-url': () => 'https://foo.bar',
+				'registry-auth-token': tokenStub
+			}).resolveFromNpm(path, path, {name: '@rexxars/ied', spec: '^2.1.0'}).subscribe(res => {
+				assert.equal(res.target, shasum)
+				done()
+			})
+		})
+	})
+})


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] a test is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)
- install
- registry
##### Description of change

By utilizing [registry-auth-token](https://github.com/rexxars/registry-auth-token), this change ensures that ied resolves which registry to use for a given scope in the same manner as NPM does, and fetches any associated auth token for the registry.

By using the correct registry URL and sending the bearer token along, this allows ied to install private packages from both the public npm registry and private registries.

We're currently using [Sinopia](https://github.com/rlidwka/sinopia) at our company, which unfortunately doesn't support the same `/<packageName>/<versionSelector>` endpoint, so I had to add some logic to resolve the correct version from the full package details endpoint (`/<packageName>`). Not super happy with the cleanliness of the "legacy mode" as I called it, so feel free to change it however you feel.

I could possibly add some tests, but it's quite hard to mock because of how the `rc` module caches its results, along with how it resolves `.npmrc` files. I had to resort to some ugly hacks in [registry-auth-token](https://github.com/rexxars/registry-auth-token/blob/master/test.js).

Feedback? This should address parts of #7 and possibly #122.
