### PR TITLE
Add support for git public/private remotes

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1,0 +1,69 @@
+
+import {spawn} from 'child_process'
+import {Observable} from 'rxjs/Observable'
+import {mergeMap} from 'rxjs/operator/mergeMap'
+import {retryWhen} from 'rxjs/operator/retryWhen'
+import {getTmp} from './cache'
+import * as util from './util'
+import * as config from './config'
+import path from 'path'
+
+import debuglog from './debuglog'
+
+const log = debuglog('git')
+
+function prefixGitArgs () {
+	return process.platform === 'win32' ? ['-c', 'core.longpaths=true'] : []
+}
+
+function spawnGit (args) {
+	log(`executing git with args ${args}`)
+	const fullArgs = prefixGitArgs().concat(args || [])
+	return spawn('git', fullArgs)
+}
+
+/**
+ * clone a git repository.
+ * @param {String} repo - git repository to clone.
+ * @param {String} ref - git reference to checkout.
+ * @return {Observable} - observable sequence that will be completed once
+ * the git repository has been cloned.
+ */
+export function clone (repo, ref) {
+	return Observable.create((observer) => {
+		const tmpDest = getTmp()
+
+		const completeHandler = () => {
+			observer.next(tmpDest)
+			observer.complete()
+		}
+		const errorHandler = (err) => {
+			log(`failed to clone repository from ${repo}`)
+			observer.error(err)
+		}
+		const args = ['clone', '-b', ref, repo, tmpDest, '--single-branch']
+		log(`cloning git repository from ${repo}`)
+		const git = spawnGit(args)
+		git.on('close', code => (code ? errorHandler() : completeHandler()))
+	})
+}
+
+/**
+ * extract a cloned git repository to destination.
+ * @param {String} dest - pathname into which the cloned repository should be
+ * extracted.
+ * @return {Observable} - observable sequence that will be completed once
+ * the cloned repository has been extracted.
+ */
+export function extract (dest) {
+	const {pkgJson, target} = this
+	const tmpDest = pkgJson.dist.path
+	const where = path.join(dest, '..', config.storageDir, target, 'package')
+	return util.rename(tmpDest, where)
+		::retryWhen((errors) => errors::mergeMap((error) => {
+			if (error.code !== 'ENOENT') {
+				throw error
+			}
+			return util.mkdirp(path.dirname(dest))
+		}))
+}


### PR DESCRIPTION


##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [ ] a test is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

`install`


##### Description of change

Added support for git endpoints. However did not found a public git remote with a known ssh host key to test against. GitHub/Bitbucket/GitLab git-like url are automatically resolved as tarballs currently (via npm-package-arg).

Does allow private ssh git clone given that you have a working `SSH_AUTH_SOCK` in your environment (eg. passwordless ssh).

