### PR TITLE
Add --production flag

### DIFF
--- a/USAGE.txt
+++ b/USAGE.txt
@@ -29,6 +29,7 @@
                         (default: http://registry.npmjs.org/)
     -b, --build         execute lifecycle scripts upon completion
                         (e.g. postinstall)
+    -prod, --production only install dependencies and optionalDependencies
 
   Example:
     ied install

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -13,7 +13,8 @@ const alias = {
 	D: 'save-dev',
 	O: 'save-optional',
 	r: 'registry',
-	b: 'build'
+	b: 'build',
+	prod: 'production'
 }
 
 const string = [
@@ -26,7 +27,8 @@ const boolean = [
 	'save',
 	'save-dev',
 	'save-optional',
-	'build'
+	'build',
+	'production'
 ]
 
 const cwd = process.cwd()

--- a/src/install.js
+++ b/src/install.js
@@ -291,7 +291,7 @@ export function resolve (nodeModules, parentTarget, isExplicit) {
  * @return {Observable} - an observable sequence of resolved dependencies.
  */
 export function resolveAll (nodeModules, targets = Object.create(null), isExplicit) {
-	return this::expand(({target, pkgJson, isEntry = false}) => {
+	return this::expand(({target, pkgJson, isEntry = false, isProd = false}) => {
 		// cancel when we get into a circular dependency
 		if (target in targets) {
 			log(`aborting due to circular dependency ${target}`)
@@ -301,7 +301,9 @@ export function resolveAll (nodeModules, targets = Object.create(null), isExplic
 		targets[target] = true // eslint-disable-line no-param-reassign
 
 		// install devDependencies of entry dependency (project-level)
-		const fields = isEntry ? ENTRY_DEPENDENCY_FIELDS : DEPENDENCY_FIELDS
+		const fields = (isEntry && !isProd)
+			? ENTRY_DEPENDENCY_FIELDS
+			: DEPENDENCY_FIELDS
 
 		log(`extracting ${fields} from ${target}`)
 

--- a/src/install_cmd.js
+++ b/src/install_cmd.js
@@ -23,12 +23,13 @@ import * as config from './config'
 export default function installCmd (cwd, argv) {
 	const isExplicit = argv._.length - 1
 	const updatedPkgJSONs = isExplicit ? fromArgv(cwd, argv) : fromFs(cwd)
+	const isProd = argv.production
 
 	const nodeModules = path.join(cwd, 'node_modules')
 	const target = path.relative(config.storageDir, '.')
 
 	const resolvedAll = updatedPkgJSONs
-		::map((pkgJson) => ({pkgJson, target, isEntry: true}))
+		::map((pkgJson) => ({pkgJson, target, isEntry: true, isProd}))
 		::resolveAll(nodeModules, undefined, isExplicit)::skip(1)
 		::publishReplay().refCount()
 


### PR DESCRIPTION
- [ ] tests and code linting passes
- [ ] a test is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

Adds a --production flag (similar to npm). If `--production=true`, `devDependencies` will be ignored during the installation.
