### PR TITLE
Revert "Add configurable storage directory that defaults to `node_mod…

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -59,13 +59,13 @@ export function build (nodeModules, dep) {
 		const env = {npm_execpath: '', ...process.env}
 
 		env.PATH = [
-			path.join(config.storageDir, target, 'node_modules', '.bin'),
+			path.join(nodeModules, target, 'node_modules', '.bin'),
 			path.resolve(__dirname, '..', 'node_modules', '.bin'),
 			process.env.PATH
 		].join(path.delimiter)
 
 		const childProcess = spawn(config.sh, [config.shFlag, script], {
-			cwd: path.join(config.storageDir, target, 'package'),
+			cwd: path.join(nodeModules, target, 'package'),
 			env,
 			stdio: 'inherit'
 			// shell: true // does break `dtrace-provider@0.6.0` build

--- a/src/config.js
+++ b/src/config.js
@@ -29,14 +29,6 @@ export const registry = env.IED_REGISTRY || 'https://registry.npmjs.org/'
 export const cacheDir = env.IED_CACHE_DIR || path.join(home, '.ied_cache')
 
 /**
- * directory used for locally installed `node_modules`.
- * configurable via `IED_STORAGE_DIR`, default to `node_modules/.cas`
- * @type {String}
- */
-export const storageDir = env.IED_STORAGE_DIR ||
-  path.join('node_modules', '.cas')
-
-/**
  * directory used for globally installed `node_modules`.
  * configurable via `IED_GLOBAL_NODE_MODULES`, default to `.node_modules` in
  * the user's home directory.

--- a/src/install.js
+++ b/src/install.js
@@ -90,8 +90,8 @@ export function resolveLocal (nodeModules, parentTarget, name, version, isExplic
 	if (version.substr(0, 5) === 'file:') {
 		log(`resolved ${name}@${version} as local symlink`)
 		const isScoped = name.charAt(0) === '@'
-		const src = path.join('..', isScoped ? '..' : '', version.substr(5))
-		const dst = path.join(config.storageDir, parentTarget, 'node_modules', name)
+		const src = path.join(parentTarget, isScoped ? '..' : '', version.substr(5))
+		const dst = path.join('node_modules', parentTarget, 'node_modules', name)
 		return util.forceSymlink(src, dst)::_finally(progress.complete)
 	}
 
@@ -291,7 +291,7 @@ export function resolve (nodeModules, parentTarget, isExplicit) {
  * @return {Observable} - an observable sequence of resolved dependencies.
  */
 export function resolveAll (nodeModules, targets = Object.create(null), isExplicit) {
-	return this::expand(({target, pkgJson, isEntry = false, isProd = false}) => {
+	return this::expand(({target, pkgJson, isProd = false}) => {
 		// cancel when we get into a circular dependency
 		if (target in targets) {
 			log(`aborting due to circular dependency ${target}`)
@@ -301,7 +301,7 @@ export function resolveAll (nodeModules, targets = Object.create(null), isExplic
 		targets[target] = true // eslint-disable-line no-param-reassign
 
 		// install devDependencies of entry dependency (project-level)
-		const fields = (isEntry && !isProd)
+		const fields = (target === '..' && !isProd)
 			? ENTRY_DEPENDENCY_FIELDS
 			: DEPENDENCY_FIELDS
 
@@ -326,8 +326,8 @@ function getBinLinks (dep) {
 	const names = Object.keys(bin)
 	for (let i = 0; i < names.length; i++) {
 		const name = names[i]
-		const src = path.join(config.storageDir, target, 'package', bin[name])
-		const dst = path.join(config.storageDir, parentTarget, 'node_modules', '.bin', name)
+		const src = path.join('node_modules', target, 'package', bin[name])
+		const dst = path.join('node_modules', parentTarget, 'node_modules', '.bin', name)
 		binLinks.push([src, dst])
 	}
 	return binLinks
@@ -335,8 +335,8 @@ function getBinLinks (dep) {
 
 function getDirectLink (dep) {
 	const {parentTarget, target, name} = dep
-	const src = path.join(config.storageDir, target, 'package')
-	const dst = path.join(config.storageDir, parentTarget, 'node_modules', name)
+	const src = path.join('node_modules', target, 'package')
+	const dst = path.join('node_modules', parentTarget, 'node_modules', name)
 	return [src, dst]
 }
 
@@ -411,7 +411,7 @@ function fixPermissions (target, bin) {
 
 function fetch (nodeModules) {
 	const {target, type, pkgJson: {name, bin, dist: {tarball, shasum}}} = this
-	const where = path.join(nodeModules, '..', config.storageDir, target, 'package')
+	const where = path.join(nodeModules, target, 'package')
 
 	log(`fetching ${tarball} into ${where}`)
 

--- a/src/install_cmd.js
+++ b/src/install_cmd.js
@@ -11,7 +11,6 @@ import {resolveAll, fetchAll, linkAll} from './install'
 import {init as initCache} from './cache'
 import {fromArgv, fromFs, save} from './pkg_json'
 import {buildAll} from './build'
-import * as config from './config'
 
 /**
  * run the installation command.
@@ -26,10 +25,9 @@ export default function installCmd (cwd, argv) {
 	const isProd = argv.production
 
 	const nodeModules = path.join(cwd, 'node_modules')
-	const target = path.relative(config.storageDir, '.')
 
 	const resolvedAll = updatedPkgJSONs
-		::map((pkgJson) => ({pkgJson, target, isEntry: true, isProd}))
+		::map((pkgJson) => ({pkgJson, target: '..', isProd}))
 		::resolveAll(nodeModules, undefined, isExplicit)::skip(1)
 		::publishReplay().refCount()
 


### PR DESCRIPTION
```
~/r/i/example (fix-dir) $ env NODE_DEBUG=install ied i is-array
🕐  INSTALL 47919: extracting dependencies,devDependencies,optionalDependencies from ../..
INSTALL 47919: resolving is-array@*
INSTALL 47919: resolving /Users/alex/repos/ied/node_modules/is-array from node_modules
INSTALL 47919: failed to resolve is-array@* from local ../.. via /Users/alex/repos/ied/example/node_modules
INSTALL 47919: resolving is-array@* from remote registry
INSTALL 47919: resolving is-array@* from npm
🕒  0% resolving is-array@*INSTALL 47919: resolved is-array@* to tarball shasum e9850cc2cc860c3bc0977e84ccf0dd464584279a from npm
INSTALL 47919: symlinking .cas/e9850cc2cc860c3bc0977e84ccf0dd464584279a/package -> node_modules/is-array
INSTALL 47919: fetching http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz into /Users/alex/repos/ied/example/node_modules/.cas/e9850cc2cc860c3bc0977e84ccf0dd464584279a/package
INSTALL 47919: extracting dependencies,optionalDependencies from e9850cc2cc860c3bc0977e84ccf0dd464584279a
INSTALL 47919: fixing persmissions of  in /Users/alex/repos/ied/example/node_modules/.cas/e9850cc2cc860c3bc0977e84ccf0dd464584279a/package
INSTALL 47919: downloading http://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz, expecting e9850cc2cc860c3bc0977e84ccf0dd464584279a
INSTALL 47919: downloaded e9850cc2cc860c3bc0977e84ccf0dd464584279a into /Users/alex/.ied_cache/.tmp/6e8512f3-1e4e-4231-a17c-59e0344fdcad
```

ied was installing the dependencies into the wrong directory:

```
See INSTALL 47919: resolving /Users/alex/repos/ied/node_modules/is-array from node_modules
```

`pwd`:

```
~/r/i/example (fix-dir) $ pwd
/Users/alex/repos/ied/example
```

After revert:

```
INSTALL 48165: resolving /Users/alex/repos/ied/example/node_modules/tape from node_modules
```

I'm reverting this for now to unbreak things, I still think the `.cad` is a great idea.
cc @mgcrea 