### PR TITLE
Fix broken install for package using caret version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lodash.memoize": "^4.1.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "needle": "^1.0.0",
+    "needle": "1.0.0",
     "node-gyp": "^3.4.0",
     "node-pre-gyp": "^0.6.29",
     "node-uuid": "^1.4.7",


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes

##### Affected core subsystem(s)

none

##### Description of change

Fix #164 

Needle package has released a new version (1.1.0) with automatically encode URI which result in a 404 for any call to NPM registry with a version range.

Example: babel-plugin-transform-es2015-parameters >=6.9.0 <7.0.0
`https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/%3E=6.9.0%20%3C7.0.0`

If you try this URL in a browser or with CURL it will works and give you a valid response with a 200 status code but not with `needle`.


