### PR TITLE
config.storageDir is no longer present

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -58,7 +58,7 @@ export function clone (repo, ref) {
 export function extract (dest) {
 	const {pkgJson, target} = this
 	const tmpDest = pkgJson.dist.path
-	const where = path.join(dest, '..', config.storageDir, target, 'package')
+	const where = path.join(dest, target, 'package')
 	return util.rename(tmpDest, where)
 		::retryWhen((errors) => errors::mergeMap((error) => {
 			if (error.code !== 'ENOENT') {


### PR DESCRIPTION
Fixes:

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:8:11)
    at Object.posix.join (path.js:479:5)
    at Object.extract [as fetch] (/usr/local/lib/node_modules/ied/lib/git.js:93:29)
    at MergeMapSubscriber.fetchWithRetry [as project] (/usr/local/lib/node_modules/ied/lib/install.js:633:28)
    at MergeMapSubscriber._tryNext (/usr/local/lib/node_modules/ied/node_modules/rxjs/operator/mergeMap.js:110:27)
    at MergeMapSubscriber._next (/usr/local/lib/node_modules/ied/node_modules/rxjs/operator/mergeMap.js:100:18)
    at MergeMapSubscriber.Subscriber.next (/usr/local/lib/node_modules/ied/node_modules/rxjs/Subscriber.js:89:18)
    at DistinctSubscriber._next (/usr/local/lib/node_modules/ied/node_modules/rxjs/operator/distinct.js:75:26)
    at DistinctSubscriber.Subscriber.next (/usr/local/lib/node_modules/ied/node_modules/rxjs/Subscriber.js:89:18)
    at RefCountSubscriber.Subscriber._next (/usr/local/lib/node_modules/ied/node_modules/rxjs/Subscriber.js:125:26)
```