### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "needle": "1.0.0",
     "node-gyp": "^3.4.0",
     "node-pre-gyp": "^0.6.29",
-    "node-uuid": "^1.4.7",
     "npm-package-arg": "^4.2.0",
     "ora": "^0.2.3",
     "rimraf": "^2.5.3",
     "rxjs": "5.0.0-rc.1",
     "semver": "^5.2.0",
     "source-map-support": "^0.4.1",
-    "tar-fs": "^1.13.0"
+    "tar-fs": "^1.13.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/src/cache.js
+++ b/src/cache.js
@@ -5,7 +5,7 @@ import gunzip from 'gunzip-maybe'
 import tar from 'tar-fs'
 import fs from 'fs'
 import path from 'path'
-import uuid from 'node-uuid'
+import uuid from 'uuid'
 import * as util from './util'
 import * as config from './config'
 

--- a/test/spec/cache.spec.js
+++ b/test/spec/cache.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import stream from 'stream'
 import tar from 'tar-fs'
 import path from 'path'
-import uuid from 'node-uuid'
+import uuid from 'uuid'
 import {Observable} from 'rxjs/Observable'
 
 import * as cache from '../../src/cache'


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.