### PR TITLE
Breaking changes in store spec

### DIFF
--- a/spec/STORE.md
+++ b/spec/STORE.md
@@ -2,16 +2,17 @@
 
 > draft, store spec version 1
 
-A store is a folder that contains installed packages and information about relationships between them.
+A store is a folder that contains packages and information about projects that are using them.
+The store does not include the `node_modules` folder of any of the packages, unless it has
+[bundled dependencies](https://docs.npmjs.com/files/package.json#bundleddependencies).
 
-These store spec tries to satisfy the following requirements:
+This store spec tries to satisfy the following requirements:
 
 1. the store has to be human-friendly, when possible
 2. the store structure should guarantee that two different packages cannot have the same path.
-3. the destination path of a package should be known after the resolve step (before fetch).
-4. it should preserve the original tarball so that the package integrity can be re-evaluated
-5. the store structure should enable indefinite caching
-6. the store structure should be sufficient to act as a storage backend of a registry
+3. it should preserve the original tarball so that the package integrity can be re-evaluated
+4. the store structure should enable indefinite caching
+5. the store structure should be sufficient to act as a storage backend of a registry
 
 Pitfalls to watch out for:
 - Mutable version tags (ie git, 'latest')
@@ -44,9 +45,9 @@ registry.npmjs.org/@cycle/dom/14.1.0
 registry.node-modules.io/@wmhilton/log/1.1.0
 ```
 
-### Packages from git
+### Packages from Git
 
-`<git URL domain>/<git path>/<commit hash>`
+`<Git URL domain>/<Git path>/<commit hash>`
 
 E.g.: `github.com/alexGugel/ied/b246270b53e43f1dc469df0c9b9ce19bb881e932`
 

--- a/spec/STORE.md
+++ b/spec/STORE.md
@@ -69,49 +69,22 @@ Local dependencies are symlinked in a Windows/MacOS/Linux compatible way, not co
 
 ## `store.yaml`
 
-A file that contains the store graph. All keys should be sorted.
-
-The store.yaml is the single place of truth. If something in the filesystem does not match the graph described in the store.yaml, the corrupted/incorrect directories of the store are recreated.
-
-### `storeSpecVersion`
-
-A string adhering to semantic versioning that specifies with which store spec is the store compatible.
-
-### `packages[packageId].dependents`
-
-A dictionary that shows what packages are dependent on each of the package from the store. The dependent packages can be other packages from the store, or packages that use the store to install their dependencies.
-
-For example, `pnpm` has a dependency on `npm` and `semver`. But `semver` is also a dependency of `npm`. It means that after installation, the `store.yaml` would have connections like this in the `dependents` property:
+A file in the root of store that contains information about projects relying on specific packages from the store.
+The `store.yaml` is a [YAML](http://yaml.org/) file with sorted keys.
 
 ```yaml
-packages:
-  registry.npmjs.org/semver/5.3.0:
-    dependents:
-      - /home/john_smith/src/pnpm
-      - registry.npmjs.org/npm/3.10.2
-  registry.npmjs.org/npm@3.10.2:
-    dependents:
-      - /home/john_smith/src/pnpm
-```
-
-### `packages[packageId].dependencies`
-
-A dictionary that is the opposite of `dependents`. However, it contains not just a list of dependency names but a map of the dependencies to their exact resolved ID.
-
-```yaml
-packages:
-  /home/john_smith/src/pnpm:
-    dependencies:
-      npm: registry.npmjs.org/npm/3.10.2
-      semver: registry.npmjs.org/semver/5.3.0
-  registry.npmjs.org/npm@3.10.2:
-    dependencies:
-      semver: registry.npmjs.org/semver/5.3.0
+/home/john_smith/src/ied:
+  - registry.npmjs.org/npm/3.10.2
+/home/john_smith/src/ied:
+  - registry.npmjs.org/arr-flatten/1.0.1
+  - registry.npmjs.org/byline/5.0.0
+  - registry.npmjs.org/cache-manager/2.2.0
 ```
 
 ## `.modules.yaml`
 
 A file in the root of node_modules with meta information.
+The `.modules.yaml` is a [YAML](http://yaml.org/) file with sorted keys.
 
 ### `storePath`
 


### PR DESCRIPTION
I realized that a machine store cannot contain the node_modules folders and the relationships between packages, because they may differ in different projects that are using the store.